### PR TITLE
Alter the check and call mechanisms for the experimental full API

### DIFF
--- a/10-zwave.js
+++ b/10-zwave.js
@@ -396,13 +396,13 @@ module.exports = function(RED) {
 			 * {"topic": "someOpenZWaveCommand", "payload": [1, 2, 3]}
 			 * */
 			default:
-				if (ozwDriver.hasOwnProperty(msg.topic) &&
+				if (msg.topic in ozwDriver &&
 					typeof ozwDriver[msg.topic] === 'function' &&
 					payload.constructor.name === 'Array'
 					) {
-						console.log('attempting direct call to OpenZWave API: %s(%s)', msg.topic, payload);
+						if (debug) console.log('attempting direct call to OpenZWave API: %s(%s)', msg.topic, payload);
 						try {
-							ozwDriver[msg.topic](payload.args);
+							ozwDriver[msg.topic].apply(ozwDriver, payload);
 						} catch(err) {
 							node.warn('direct OpenZWave call to '+ msg.topic+' failed: '+err);
 						}


### PR DESCRIPTION
I wasn't able to get the experimental API working with my installation.

 - openzwave@40eb7304f8157b6ea2cb5b67b4806f696f297787
 - openzwave-shared@1.1.7 (npm installed)
 - node-red@0.13.3 (npm installed)
 - node-red-contrib-openzwave@bdefef77f6e5b661faf16f6ae44c253c0fb03aea

Running on top of current raspbian jessie, let me know if any more versions of libs are needed to reproduce.

Test setup:
 - verify that the node's not polling currently by having an inject node send `global.openzwaveNodes.5.classes.38.1.0.is_polled` to debug; should be false.
 - inject node, send a topic of `enablePoll` and a payload of `[5, 38, 1]` (which is close to the example in the docs) to a zwave output node
 - check again on the `global.openzwaveNodes.5.classes.38.1.0.is_polled`, should be true (ends up being false in bdefef77f6e5b661faf16f6ae44c253c0fb03aea but true with these changes)

I'll preface this by saying I'm not great with javascript, but I found what I think are two issues with the current implementation (at least with the versions of everything I have installed):

 1. `ozwDriver.hasOwnProperty(msg.topic)` doesn't seem to match the functions, while `msg.topic in ozwDriver` does find them when they exist. I don't know js internals well enough to comprehend why that's happening, I just know that I'd never get into that block without the change.
 2. `ozwDriver[msg.topic](payload.args)` doesn't seem to be putting the arguments into the function call correctly - `ozwDriver[msg.topic].apply(ozwDriver, payload);` seems to do the job.