### PR TITLE
Added a new config option to the config node and fixed driver attempts and poll interval

### DIFF
--- a/10-zwave.html
+++ b/10-zwave.html
@@ -23,12 +23,20 @@
         <input type="text" id="node-config-input-port">
     </div>
     <div class="form-row">
+        <p style="text-align: center">Node-RED restart required after changing:</p>
+    </div>
+    <div class="form-row">
         <label for="node-config-input-driverattempts"><i class="icon-bookmark"></i> Driver attempts</label>
         <input type="text" id="node-config-input-driverattempts">
     </div>
     <div class="form-row">
-        <label for="node-config-input-pollinterval"><i class="icon-bookmark"></i> Poll interval</label>
-        <input type="text" id="node-config-input-pollinterval">
+        <label for="node-config-input-pollinterval"><i class="icon-bookmark"></i> Poll interval (ms)</label>
+        <input type="text" id="node-config-input-pollinterval" placeholder="10000 ms">
+    </div>
+    <div class="form-row">
+        <label for="node-config-input-allowunreadyupdates" style="vertical-align: top"><i class="icon-bookmark"></i> Pre-wake Updates</label>
+        <input type="checkbox" id="node-config-input-allowunreadyupdates" style="display: inline-block; width: auto; vertical-align: top;">
+        <label for="node-config-input-allowunreadyupdates" style="width: 70%;">Allow updates from devices not fully scanned?</label>
     </div>
 </script>
 
@@ -84,7 +92,8 @@
 			name:       {value:""},
             port: {value: "/dev/ttyUSB0", required:true},
             driverattempts: {value: 3,	required:true, validate:RED.validators.number()},
-            pollinterval:   {value: 500, required:true, validate:RED.validators.number()},
+            pollinterval:   {value: 10000, required:true, validate:RED.validators.number()},
+            allowunreadyupdates: {value: false, required:true}
         },
 		label: function() {
 			return("openzwave@"+this.port);


### PR DESCRIPTION
 - Added new option to allow updates to be fired despite the firing node not yet being marked ready. Useful for when OZW is loading a zwcfg XML file (and thus, knows about your devices' command classes well enough to handle valueChanged events) but the nodes only wake up (allowing OZW to fully scan them) very occasionally; this allows those nodes to still function immediately after OZW startup without waking.
 - If debug is enabled, set the OZW log level to 8 to get those messages spewing too
 - Pass the driver attempts option to OZW, causing that option to function
 - Add an event handler to the config node for the 'scan complete' event which applies the poll interval option (making that option effective), as well as activating the "unready updates" config at that time
 - Set the default polling interval to 10000 ms, up from 500 ms (polling still requires either firing an enablePoll at the experimental API, or loading a zwcfg XML file that has polled properties set up)